### PR TITLE
Initialize simple frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# meme10
+# Mini Social Network
+
+This repository contains a tiny in-memory social network split into a
+React frontend (`front/`) and a Go backend (`back/`).

--- a/back/README.md
+++ b/back/README.md
@@ -1,0 +1,15 @@
+# Backend
+
+This directory contains a minimal in-memory HTTP service built with a tiny subset
+of the Twirp RPC framework. It exposes RPC-style endpoints for working with
+posts.
+
+## Running
+
+```
+go run .
+```
+
+The service listens on `:8080` and expects an `X-User` header identifying the
+current user. OAuth2 via VK can be integrated by exchanging a token for the
+VK user id and setting it in that header.

--- a/back/go.mod
+++ b/back/go.mod
@@ -1,0 +1,7 @@
+module socialnet
+
+go 1.23.8
+
+require github.com/twitchtv/twirp v0.0.0
+
+replace github.com/twitchtv/twirp => ./twirp

--- a/back/main.go
+++ b/back/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+    "log"
+    "net/http"
+
+    "socialnet/service"
+)
+
+func main() {
+    srv := service.NewServer()
+    log.Println("starting server on :8080")
+    if err := http.ListenAndServe(":8080", srv); err != nil {
+        log.Fatal(err)
+    }
+}

--- a/back/service/service.go
+++ b/back/service/service.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"socialnet/twirp"
+)
+
+// Post represents a single post in the system
+type Post struct {
+	ID        int64     `json:"id"`
+	AuthorID  string    `json:"author_id"`
+	Text      string    `json:"text"`
+	CreatedAt time.Time `json:"created_at"`
+	Deleted   bool      `json:"deleted"`
+}
+
+type Server struct {
+	mux   *http.ServeMux
+	posts []*Post
+	mu    sync.Mutex
+	next  int64
+}
+
+func NewServer() *Server {
+	s := &Server{mux: http.NewServeMux(), posts: []*Post{}, next: 1}
+	s.registerHandlers()
+	return s
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) registerHandlers() {
+	s.mux.HandleFunc("/twirp/PostService/AddPost", s.handleAddPost)
+	s.mux.HandleFunc("/twirp/PostService/DeletePost", s.handleDeletePost)
+	s.mux.HandleFunc("/twirp/PostService/GetFeed", s.handleGetFeed)
+}
+
+func (s *Server) handleAddPost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		twirp.WriteError(w, &twirp.Error{Code: "bad_route", Msg: "POST required"})
+		return
+	}
+	var req struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twirp.WriteError(w, &twirp.Error{Code: "malformed", Msg: "cannot decode"})
+		return
+	}
+	author := r.Header.Get("X-User")
+	if author == "" {
+		twirp.WriteError(w, &twirp.Error{Code: "unauthenticated", Msg: "missing user"})
+		return
+	}
+	s.mu.Lock()
+	p := &Post{ID: s.next, AuthorID: author, Text: req.Text, CreatedAt: time.Now()}
+	s.next++
+	s.posts = append(s.posts, p)
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(p)
+}
+
+func (s *Server) handleDeletePost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		twirp.WriteError(w, &twirp.Error{Code: "bad_route", Msg: "POST required"})
+		return
+	}
+	var req struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		twirp.WriteError(w, &twirp.Error{Code: "malformed", Msg: "cannot decode"})
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, p := range s.posts {
+		if p.ID == req.ID {
+			p.Deleted = true
+			_ = json.NewEncoder(w).Encode(p)
+			return
+		}
+	}
+	twirp.WriteError(w, &twirp.Error{Code: "not_found", Msg: "post not found"})
+}
+
+func (s *Server) handleGetFeed(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		twirp.WriteError(w, &twirp.Error{Code: "bad_route", Msg: "POST required"})
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := make([]*Post, len(s.posts))
+	copy(list, s.posts)
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].CreatedAt.After(list[j].CreatedAt)
+	})
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		Posts []*Post `json:"posts"`
+	}{list})
+}

--- a/back/twirp/twirp.go
+++ b/back/twirp/twirp.go
@@ -1,0 +1,27 @@
+package twirp
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Error struct {
+	Code string `json:"code"`
+	Msg  string `json:"msg"`
+}
+
+func (e *Error) Error() string { return e.Msg }
+
+func WriteError(w http.ResponseWriter, err error) {
+	te, ok := err.(*Error)
+	if !ok {
+		te = &Error{Code: "internal", Msg: err.Error()}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(te)
+}
+
+type Server interface {
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}

--- a/front/README.md
+++ b/front/README.md
@@ -1,0 +1,2 @@
+Simple React frontend for the mini social network.
+Open `index.html` in the browser to run.

--- a/front/app.js
+++ b/front/app.js
@@ -1,0 +1,46 @@
+const { useState, useEffect } = React;
+
+function App() {
+  const [posts, setPosts] = useState([]);
+  const [text, setText] = useState("");
+
+  const fetchFeed = async () => {
+    const resp = await fetch('/twirp/PostService/GetFeed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}'
+    });
+    const data = await resp.json();
+    if (data.posts) setPosts(data.posts);
+  };
+
+  useEffect(() => { fetchFeed(); }, []);
+
+  const addPost = async () => {
+    await fetch('/twirp/PostService/AddPost', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    });
+    setText('');
+    fetchFeed();
+  };
+
+  return (
+    <div>
+      <div>
+        <input value={text} onChange={e => setText(e.target.value)} />
+        <button onClick={addPost}>Post</button>
+      </div>
+      <ul>
+        {posts.map(p => (
+          <li key={p.id} style={{textDecoration: p.deleted ? 'line-through' : 'none'}}>
+            [{new Date(p.created_at).toLocaleString()}] {p.text}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/front/index.html
+++ b/front/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Mini Social Network</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold React frontend with basic posting UI
- implement minimal Twirp-like backend service in Go
- store posts in memory and expose Add/Delete/GetFeed RPCs
- document how to run the backend

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685fb6a55e70832b98eae0251e113bbb